### PR TITLE
chore: add krew-release-bot for automating PRs to krew-index

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -47,3 +47,6 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         asset_paths: '["./release/*.gz"]'
+
+    - name: Update new version in krew-index
+      uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: nginx-supportpkg
+spec:
+  version: {{ .TagName }}
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/nginxinc/nginx-supportpkg-for-k8s/releases/download/{{ .TagName }}/kubectl-nginx_supportpkg_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-nginx_supportpkg
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/nginxinc/nginx-supportpkg-for-k8s/releases/download/{{ .TagName }}/kubectl-nginx_supportpkg_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-nginx_supportpkg
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/nginxinc/nginx-supportpkg-for-k8s/releases/download/{{ .TagName }}/kubectl-nginx_supportpkg_{{ .TagName }}_darwin_arm64.tar.gz" .TagName}}
+    bin: kubectl-nginx_supportpkg
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/nginxinc/nginx-supportpkg-for-k8s/releases/download/{{ .TagName }}/kubectl-nginx_supportpkg_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-nginx_supportpkg
+  shortDescription: Collect support packages for NGINX products that run on k8s
+  homepage: https://github.com/nginxinc/nginx-supportpkg-for-k8s
+  description: |
+    Provides a single command to collect troubleshooting information
+    for all NGINX products that run on k8s.


### PR DESCRIPTION
Changes to automate PRs to krew-index via [krew-release-bot](https://krew.sigs.k8s.io/docs/developer-guide/release/automating-updates/):

- [x] `.krew.yaml` template included.
- [x] Template validated via [Testing the template file](https://github.com/rajatjindal/krew-release-bot#testing-the-template-file).
- [x] `.github/workflows/release-builder.yml` modified to add the `krew-release-bot`github action.