### PR TITLE
Issue 19: Log command-line arguments at start

### DIFF
--- a/cmd/nginx-supportpkg.go
+++ b/cmd/nginx-supportpkg.go
@@ -46,6 +46,7 @@ func Execute() {
 			}
 
 			collector.Logger.Printf("Starting kubectl-nginx-suportpkg - version: %s - build: %s", version.Version, version.Build)
+			collector.Logger.Printf("Input args are %v", os.Args)
 
 			switch product {
 			case "nic":


### PR DESCRIPTION
* Log the command-line input by the user
* os.Args hold the command-line arguments, starting with the program name

Example:
`2024/07/11 03:30:41.601650 nginx-supportpkg.go:48: Starting kubectl-nginx-suportpkg - version: dev - build: dev
2024/07/11 03:30:41.601736 nginx-supportpkg.go:49: Input args are [/usr/local/bin/kubectl-nginx_supportpkg -n kic-0 -p nic]`