### PR TITLE
Use filepath tools for Windows compatibility

### DIFF
--- a/pkg/data_collector/data_collector.go
+++ b/pkg/data_collector/data_collector.go
@@ -162,7 +162,7 @@ func (c *DataCollector) WrapUp(product string) (string, error) {
 		if err != nil {
 			return err
 		}
-		header.Name = tarballRootDirName + "/" + relativePath
+		header.Name = filepath.ToSlash(filepath.Join(tarballRootDirName, relativePath))
 
 		if err = tw.WriteHeader(header); err != nil {
 			return err


### PR DESCRIPTION
The PR uses `filepath.ToSlash` and `filepath.Join`in order to be consistent with how supportpkg tarballs are created, regardless of the OS in which the plugin runs.

Needs Windows testing.

Closes #22 