### PR TITLE
Fix: Issue 23: Collect nginx-ingress version in the NIC pods

### DIFF
--- a/pkg/jobs/nic_job_list.go
+++ b/pkg/jobs/nic_job_list.go
@@ -435,6 +435,32 @@ func NICJobList() []Job {
 			},
 		},
 		{
+			Name:    "exec-nginx-ingress-version",
+			Timeout: time.Second * 10,
+			Execute: func(dc *data_collector.DataCollector, ctx context.Context, ch chan JobResult) {
+				jobResult := JobResult{Files: make(map[string][]byte), Error: nil}
+				command := []string{"./nginx-ingress", "--version"}
+				for _, namespace := range dc.Namespaces {
+					pods, err := dc.K8sCoreClientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+					if err != nil {
+						dc.Logger.Printf("\tCould not retrieve pod list for namespace %s: %v\n", namespace, err)
+					} else {
+						for _, pod := range pods.Items {
+							if strings.Contains(pod.Name, "ingress") {
+								res, err := dc.PodExecutor(namespace, pod.Name, command, ctx)
+								if err != nil {
+									dc.Logger.Printf("\tCommand execution %s failed for pod %s in namespace %s: %v\n", command, pod.Name, namespace, err)
+								} else {
+									jobResult.Files[path.Join(dc.BaseDir, "exec", namespace, pod.Name+"__nginx-ingress-version.txt")] = res
+								}
+							}
+						}
+					}
+				}
+				ch <- jobResult
+			},
+		},
+		{
 			Name:    "crd-objects",
 			Timeout: time.Second * 10,
 			Execute: func(dc *data_collector.DataCollector, ctx context.Context, ch chan JobResult) {


### PR DESCRIPTION
* Add a new job to the NIC job list to execute `./nginx-ingress --version` within the pod
* The collected information as an example with 2 pods:
```
./exec
├── kic-0
└── mr-kic-0

$ cat exec/kic-0/kic-0-nginx-ingress-controller-5cc89947fb-r4s7t__nginx-ingress-version.txt
NGINX Ingress Controller Version=3.4.3 Commit=3b14d1d09e7cd07ea769fdaa968bab68b7b7319e Date=2024-02-19T12:13:45Z DirtyState=false Arch=linux/amd64 Go=go1.21.3

$ cat exec/mr-kic-0/mr-kic-0-nginx-ingress-controller-758757f7bc-hpw2d__nginx-ingress-version.txt
NGINX Ingress Controller Version=3.3.2 Commit=d239c207534aaa4fc524fb276f8d44330dbe8571 Date=2023-11-01T19:57:35Z DirtyState=false Arch=linux/amd64 Go=go1.21.3

```