### PR TITLE
Extend timeout for log collection

### DIFF
--- a/cmd/nginx-supportpkg.go
+++ b/cmd/nginx-supportpkg.go
@@ -60,11 +60,13 @@ func Execute() {
 			}
 
 			if collector.AllNamespacesExist() {
+				failedJobs := 0
 				for _, job := range jobList {
 					fmt.Printf("Running job %s...", job.Name)
 					err = job.Collect(collector)
 					if err != nil {
 						fmt.Printf(" Error: %s\n", err)
+						failedJobs++
 					} else {
 						fmt.Print(" OK\n")
 					}
@@ -75,7 +77,13 @@ func Execute() {
 					fmt.Println(fmt.Errorf("error when wrapping up: %s", err))
 					os.Exit(1)
 				} else {
-					fmt.Printf("Supportpkg successfully generated: %s\n", tarFile)
+					if failedJobs == 0 {
+						fmt.Printf("Supportpkg successfully generated: %s\n", tarFile)
+					} else {
+						fmt.Printf("WARNING: %d failed job(s)\n", failedJobs)
+						fmt.Printf("Supportpkg generated with warnings: %s\n", tarFile)
+					}
+
 				}
 			} else {
 				fmt.Println(" Error: Some namespaces do not exist")

--- a/pkg/jobs/common_job_list.go
+++ b/pkg/jobs/common_job_list.go
@@ -52,7 +52,7 @@ func CommonJobList() []Job {
 		},
 		{
 			Name:    "collect-pods-logs",
-			Timeout: time.Second * 30,
+			Timeout: time.Second * 120,
 			Execute: func(dc *data_collector.DataCollector, ctx context.Context, ch chan JobResult) {
 				jobResult := JobResult{Files: make(map[string][]byte), Error: nil}
 				for _, namespace := range dc.Namespaces {

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -50,7 +50,7 @@ func (j Job) Collect(dc *data_collector.DataCollector) error {
 
 	select {
 	case <-ctx.Done():
-		dc.Logger.Printf("\tJob %s has timed out: %s\n", j.Name, ctx.Err())
+		dc.Logger.Printf("\tJob %s has timed out: %s\n---\n", j.Name, ctx.Err())
 		return errors.New(fmt.Sprintf("Context cancelled: %v", ctx.Err()))
 
 	case jobResults := <-ch:


### PR DESCRIPTION
This PR addresses the following changes:

- `collect-pods-logs` job timeout is increased to 120 seconds.
- Warnings are issued in the stdout when one or more jobs fail.