### PR TITLE
Issue 41: Add support for NGINX containers in k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A kubectl plugin designed to collect diagnostics information on any NGINX produc
 
 ## Supported products
 
-Currently, [NIC](https://github.com/nginxinc/kubernetes-ingress) is the only supported product.
+Currently, [NIC](https://github.com/nginxinc/kubernetes-ingress), [NGF](https://github.com/nginxinc/nginx-gateway-fabric) and [NGINX (OSS/NPLUS) in containers](https://github.com/nginx/nginx) are the supported products.
 
 ## Features
 

--- a/cmd/nginx-supportpkg.go
+++ b/cmd/nginx-supportpkg.go
@@ -20,12 +20,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"slices"
+
 	"github.com/nginxinc/nginx-k8s-supportpkg/pkg/data_collector"
 	"github.com/nginxinc/nginx-k8s-supportpkg/pkg/jobs"
 	"github.com/nginxinc/nginx-k8s-supportpkg/pkg/version"
 	"github.com/spf13/cobra"
-	"os"
-	"slices"
 )
 
 func Execute() {
@@ -54,8 +55,10 @@ func Execute() {
 				jobList = slices.Concat(jobs.CommonJobList(), jobs.NICJobList())
 			case "ngf":
 				jobList = slices.Concat(jobs.CommonJobList(), jobs.NGFJobList())
+			case "ngx":
+				jobList = slices.Concat(jobs.CommonJobList(), jobs.NGXJobList())
 			default:
-				fmt.Printf("Error: product must be in the following list: [nic, ngf]\n")
+				fmt.Printf("Error: product must be in the following list: [nic, ngf, ngx]\n")
 				os.Exit(1)
 			}
 
@@ -104,8 +107,8 @@ func Execute() {
 			"Usage:" +
 			"\n nginx-supportpkg -h|--help" +
 			"\n nginx-supportpkg -v|--version" +
-			"\n nginx-supportpkg [-n|--namespace] ns1 [-n|--namespace] ns2 [-p|--product] [nic,ngf]" +
-			"\n nginx-supportpkg [-n|--namespace] ns1,ns2 [-p|--product] [nic,ngf] \n")
+			"\n nginx-supportpkg [-n|--namespace] ns1 [-n|--namespace] ns2 [-p|--product] [nic,ngf,ngx]" +
+			"\n nginx-supportpkg [-n|--namespace] ns1,ns2 [-p|--product] [nic,ngf,ngx] \n")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/pkg/jobs/ngx_job_list.go
+++ b/pkg/jobs/ngx_job_list.go
@@ -1,0 +1,62 @@
+/**
+
+Copyright 2024 F5, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+**/
+
+package jobs
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nginxinc/nginx-k8s-supportpkg/pkg/data_collector"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NGXJobList() []Job {
+	jobList := []Job{
+		{
+			Name:    "exec-nginx-t",
+			Timeout: time.Second * 10,
+			Execute: func(dc *data_collector.DataCollector, ctx context.Context, ch chan JobResult) {
+				jobResult := JobResult{Files: make(map[string][]byte), Error: nil}
+				command := []string{"/usr/sbin/nginx", "-T"}
+				for _, namespace := range dc.Namespaces {
+					pods, err := dc.K8sCoreClientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+					if err != nil {
+						dc.Logger.Printf("\tCould not retrieve pod list for namespace %s: %v\n", namespace, err)
+					} else {
+						for _, pod := range pods.Items {
+							if strings.Contains(pod.Name, "nginx") {
+								res, err := dc.PodExecutor(namespace, pod.Name, "nginx", command, ctx)
+								if err != nil {
+									jobResult.Error = err
+									dc.Logger.Printf("\tCommand execution %s failed for pod %s in namespace %s: %v\n", command, pod.Name, namespace, err)
+								} else {
+									jobResult.Files[filepath.Join(dc.BaseDir, "exec", namespace, pod.Name+"__nginx-t.txt")] = res
+								}
+							}
+						}
+					}
+				}
+				ch <- jobResult
+			},
+		},
+	}
+	return jobList
+}


### PR DESCRIPTION
* Created a distinct joblist for NGINX containers
* At present it only collects nginx -T output
* Updated readme to reflect support for NGINX and NGF containers