### PR TITLE
chore: bump go version to 1.23.4

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: '1.22.4'
+          go-version: '1.23.4'
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/nginxinc/nginx-k8s-supportpkg
 
-go 1.22.4
-toolchain go1.23.4
+go 1.23.4
 
 require (
 	github.com/mittwald/go-helm-client v0.12.15


### PR DESCRIPTION
Updating to go 1.23.4