### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,21 +21,21 @@ jobs:
         run: echo "Starting Release Build for ${RELEASE_VERSION}"
         
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: List repository files
         run: ls -R .; pwd
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3.5.0
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: nginx-utils/Dockerfile
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Trivy and scan image for vulnerabilities
         if: false
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
 
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/nginx-utils:latest
@@ -55,13 +55,13 @@ jobs:
           output: vuln-report.json
 
       - name: Upload Vulnerability Report
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vuln-report
           path: vuln-report.json
 
       - name: Update Release Notes with Docker Image Info
-        uses: softprops/action-gh-release@v2.3.2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           body: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
         go-version: '1.24'
 
@@ -28,7 +28,7 @@ jobs:
         chmod +x nginx-supportpkg
 
     - name: Create KinD cluster
-      uses: helm/kind-action@v1.12.0
+      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
       with:
         cluster_name: test-cluster
         config: .github/kind-config.yaml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Upload test artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: integration-test-artifacts
         path: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: "1.24"
 


### PR DESCRIPTION
## Summary

Pin all unpinned actions to their full commit SHAs to prevent supply-chain attacks via mutable tags.
Note: `aquasecurity/trivy-action` was also updated from `0.33.1` to `v0.35.0`.

## Changes

### `docker-build.yml`
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v5` | `@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (`# v5`) |
| `docker/setup-buildx-action` | `@v3.11.1` | `@e468171a9de216ec08956ac3ada2f0791b6bd435` (`# v3.11.1`) |
| `docker/login-action` | `@v3.5.0` | `@184bdaa0721073962dff0199f1fb9940f07167d1` (`# v3.5.0`) |
| `docker/build-push-action` | `@v6.18.0` | `@263435318d21b8e681c14492fe198d362a7d2c83` (`# v6.18.0`) |
| `aquasecurity/trivy-action` | `@0.33.1` | `@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (`# v0.35.0`) ⬆️ |
| `actions/upload-artifact` | `@v4.6.2` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` (`# v4.6.2`) |
| `softprops/action-gh-release` | `@v2.3.2` | `@72f2c25fcb47643c292f7107632f7a47c1df5cd8` (`# v2.3.2`) |

### `integration-test.yml`
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v5` | `@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (`# v5`) |
| `actions/setup-go` | `@v6` | `@4b73464bb391d4059bd26b0524d20df3927bd417` (`# v6`) |
| `helm/kind-action` | `@v1.12.0` | `@a1b0e391336a6ee6713a0583f8c6240d70863de3` (`# v1.12.0`) |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` (`# v4`) |

### `unit-tests.yml`
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v5` | `@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (`# v5`) |
| `actions/setup-go` | `@v6` | `@4b73464bb391d4059bd26b0524d20df3927bd417` (`# v6`) |